### PR TITLE
Previous button on first step of the wizard in a dialog

### DIFF
--- a/jquery.jWizard.js
+++ b/jquery.jWizard.js
@@ -706,6 +706,7 @@
 				$finish = this.element.find(".jw-button-finish");
 
 			switch ($steps.index($steps.filter(":visible"))) {
+			case -1:
 			case 0:
 				$previous.hide();
 				$next.show();


### PR DESCRIPTION
I noticed that the wizard / dialog example would show the previous button on the first step of the wizard. Clicking it was producing an "Index out of Range" error.

Commit notes:
The _updateButtons function uses a :visible selector to determine which buttons should be available. However, when jWizard is applied to a dialog that hasn't been opened, none of the steps are visible yet. That case should be treated like the "first page" case.
